### PR TITLE
Fixed bug with autofs and added Scheduled Actions for ASGs

### DIFF
--- a/SupportScripts/redmine-appinstall.sh
+++ b/SupportScripts/redmine-appinstall.sh
@@ -123,6 +123,9 @@ else
    curl -s -L "${RECONSURI}"/main_cf.sh | /bin/bash -
 fi
 
+#Restart autofs
+systemctl restart autofs
+
 # Grab and stage RedMine archive
 (
   cd /tmp && curl -L "${RMDLSRC}"/"${RMVERS}".tar.gz | \

--- a/SupportScripts/redmine-osprep.sh
+++ b/SupportScripts/redmine-osprep.sh
@@ -302,4 +302,3 @@ systemctl restart httpd && logit success || \
 
 # Try to activate epel as needed
 NeedEpel
-

--- a/Templates/make_RedMine_EC2-autoscale.tmplt.json
+++ b/Templates/make_RedMine_EC2-autoscale.tmplt.json
@@ -88,6 +88,34 @@
       "Fn::Not": [
         { "Fn::Equals": [ { "Ref": "WatchmakerConfig" }, "" ] }
       ]
+    },
+    "UseScheduledAction": {
+        "Fn::And": [
+            {
+                "Fn::Not": [
+                    {
+                        "Fn::Equals": [
+                            {
+                                "Ref": "ScaleUpSchedule"
+                            },
+                            ""
+                        ]
+                    }
+                ]
+            },
+            {
+                "Fn::Not": [
+                    {
+                        "Fn::Equals": [
+                            {
+                                "Ref": "ScaleDownSchedule"
+                            },
+                            ""
+                        ]
+                    }
+                ]
+            }
+        ]
     }
   },
   "Description": "This template creates an Autoscaling Group and Launch Configuration to deploy STIG-hardened Enterprise Linux 7 instances to host the RedMine service's web-tier.",
@@ -131,7 +159,10 @@
             "AppVolumeType",
             "NoPublicIp",
             "ToggleNewInstances",
-            "CfnEndpointUrl"
+            "CfnEndpointUrl",
+            "ScaleDownDesiredCapacity",
+            "ScaleDownSchedule",
+            "ScaleUpSchedule"
           ]
         },
         {
@@ -356,7 +387,7 @@
       "Type": "Number"
     },
     "MinCapacity": {
-      "Default": "1",
+      "Default": "0",
       "Description": "Minimum number of instances in the Autoscaling Group",
       "Type": "Number"
     },
@@ -446,6 +477,21 @@
       "Description": "Type of network share hosting shared RedMine content.",
       "Type": "String"
     },
+    "ScaleDownDesiredCapacity": {
+        "Default": "0",
+        "Description": "(Optional) Desired number of instances during the Scale Down Scheduled Action; ignored if ScaleDownSchedule is unset",
+        "Type": "Number"
+    },
+    "ScaleDownSchedule": {
+        "Default": "",
+        "Description": "(Optional) Scheduled Action in cron-format (UTC) to scale down the number of instances; ignored if empty or ScaleUpSchedule is unset (E.g. \"0 0 * * *\")",
+        "Type": "String"
+    },
+    "ScaleUpSchedule": {
+        "Default": "",
+        "Description": "(Optional) Scheduled Action in cron-format (UTC) to scale up to the Desired Capacity; ignored if empty or ScaleDownSchedule is unset (E.g. \"0 10 * * Mon-Fri\")",
+        "Type": "String"
+      },
     "SecurityGroupIds": {
       "Description": "List of security groups to apply to the instance(s)",
       "Type": "List<AWS::EC2::SecurityGroup::Id>"
@@ -547,7 +593,7 @@
       "UpdatePolicy": {
         "AutoScalingRollingUpdate": {
           "MaxBatchSize": "2",
-          "MinInstancesInService": "1",
+          "MinInstancesInService": "0",
           "PauseTime": "PT15M",
           "WaitOnResourceSignals": "true"
         }
@@ -1870,6 +1916,36 @@
         }
       },
       "Type": "AWS::AutoScaling::LaunchConfiguration"
+    },
+    "ScaleDownScheduledAction": {
+        "Condition": "UseScheduledAction",
+        "Properties": {
+            "AutoScalingGroupName": {
+                "Ref": "RedMineASG"
+            },
+            "DesiredCapacity": {
+                "Ref": "ScaleDownDesiredCapacity"
+            },
+            "Recurrence": {
+                "Ref": "ScaleDownSchedule"
+            }
+        },
+        "Type": "AWS::AutoScaling::ScheduledAction"
+    },
+    "ScaleUpScheduledAction": {
+        "Condition": "UseScheduledAction",
+        "Properties": {
+            "AutoScalingGroupName": {
+                "Ref": "RedMineASG"
+            },
+            "DesiredCapacity": {
+                "Ref": "MaxCapacity"
+            },
+            "Recurrence": {
+                "Ref": "ScaleUpSchedule"
+            }
+        },
+        "Type": "AWS::AutoScaling::ScheduledAction"
     }
   }
 }

--- a/Templates/make_RedMine_parent-autoscale-EFS.tmplt.json
+++ b/Templates/make_RedMine_parent-autoscale-EFS.tmplt.json
@@ -40,7 +40,10 @@
             "MaxCapacity",
             "MinCapacity",
             "ToggleCfnInitUpdate",
-            "ToggleNewInstances"
+            "ToggleNewInstances",
+            "ScaleDownDesiredCapacity",
+            "ScaleDownSchedule",
+            "ScaleUpSchedule"
           ]
         },
         {
@@ -308,7 +311,7 @@
       "Type": "Number"
     },
     "MinCapacity": {
-      "Default": "1",
+      "Default": "0",
       "Description": "Minimum number of instances in the Autoscaling Group",
       "Type": "Number"
     },
@@ -421,6 +424,21 @@
       "Description": "Prefix to apply to IAM role to make things a bit prettier (optional).",
       "Type": "String"
     },
+    "ScaleDownDesiredCapacity": {
+        "Default": "0",
+        "Description": "(Optional) Desired number of instances during the Scale Down Scheduled Action; ignored if ScaleDownSchedule is unset",
+        "Type": "Number"
+    },
+    "ScaleDownSchedule": {
+        "Default": "",
+        "Description": "(Optional) Scheduled Action in cron-format (UTC) to scale down the number of instances; ignored if empty or ScaleUpSchedule is unset (E.g. \"0 0 * * *\")",
+        "Type": "String"
+    },
+    "ScaleUpSchedule": {
+        "Default": "",
+        "Description": "(Optional) Scheduled Action in cron-format (UTC) to scale up to the Desired Capacity; ignored if empty or ScaleDownSchedule is unset (E.g. \"0 10 * * Mon-Fri\")",
+        "Type": "String"
+      },
     "ServiceTld": {
       "Default": "amazonaws.com",
       "Description": "TLD of the IAMable service-name.",
@@ -525,7 +543,7 @@
           "InstanceType": { "Ref": "InstanceType" },
           "KeyPairName": { "Ref": "KeyPairName" },
           "MaxCapacity": "2",
-          "MinCapacity": "1",
+          "MinCapacity": "0",
           "NoPublicIp": "true",
           "NoReboot": "false",
           "NoUpdates": { "Ref": "NoUpdates" },
@@ -547,6 +565,9 @@
             ]
           },
           "RedmineShareType": "nfs",
+          "ScaleDownDesiredCapacity": { "Ref": "ScaleDownDesiredCapacity"},
+          "ScaleDownSchedule": { "Ref": "ScaleDownSchedule"},
+          "ScaleUpSchedule": { "Ref": "ScaleUpSchedule"},
           "SecurityGroupIds": {
             "Fn::Join": [
               ",",
@@ -562,7 +583,7 @@
               ",",
               { "Ref": "ProtectedSubnets" }
             ]
-          }, 
+          },
           "ToggleCfnInitUpdate": { "Ref": "ToggleCfnInitUpdate" },
           "ToggleNewInstances": { "Ref": "ToggleNewInstances" },
           "WatchmakerConfig": { "Ref": "WatchmakerConfig" },


### PR DESCRIPTION
Fixes # .
Added autofs restart to redmine-appinstall.sh as this was causing EC2 instance deployment to fail.


Changes offered/proposed in this pull request:
- Added support for scheduled scale up and down in Scheduled Actions for the AutoScaling Group, which eliminates the current practice of adding them out of band.

* New PR Alert to: @plus3it/cfn
